### PR TITLE
FIX CmakeList to reflect SofaExporter and SofaValidation modularization

### DIFF
--- a/Regression_test/CMakeLists.txt
+++ b/Regression_test/CMakeLists.txt
@@ -4,8 +4,9 @@ project(Regression_test)
 include(cmake/environment.cmake)
 
 find_package(SofaMisc) # to include all SOFA
-find_package(SofaExporter QUIET)
-find_package(SofaGTestMain)
+find_package(SofaExporter REQUIRED)
+find_package(SofaValidation REQUIRED)
+find_package(SofaGTestMain REQUIRED)
 
 set(HEADER_FILES
     RegressionSceneList.h
@@ -20,7 +21,5 @@ set(SOURCE_FILES
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
 add_definitions("-DSOFA_SRC_DIR=\"${CMAKE_SOURCE_DIR}\"")
 target_link_libraries(${PROJECT_NAME} SofaCore SofaGTestMain SofaComponentBase SofaComponentCommon SofaComponentGeneral SofaComponentAdvanced SofaComponentMisc)
-if(SofaExporter_FOUND)
-    target_link_libraries(${PROJECT_NAME} SofaExporter)
-endif()
+target_link_libraries(${PROJECT_NAME} SofaExporter SofaValidation)
 

--- a/Regression_test/CMakeLists.txt
+++ b/Regression_test/CMakeLists.txt
@@ -23,3 +23,4 @@ add_definitions("-DSOFA_SRC_DIR=\"${CMAKE_SOURCE_DIR}\"")
 target_link_libraries(${PROJECT_NAME} SofaCore SofaGTestMain SofaComponentBase SofaComponentCommon SofaComponentGeneral SofaComponentAdvanced SofaComponentMisc)
 target_link_libraries(${PROJECT_NAME} SofaExporter SofaValidation)
 
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)


### PR DESCRIPTION
Make SofaExporter and SofaValidation required for compilation (instead of being naturally included in SofaGeneral collection)
And SofaGTest should be mandatory