### PR TITLE
Use non-deprecated header/class

### DIFF
--- a/Regression_test/RegressionSceneList.cpp
+++ b/Regression_test/RegressionSceneList.cpp
@@ -25,7 +25,7 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::FileSystem;
-#include <sofa/helper/testing/BaseTest.h>
+#include <sofa/testing/BaseTest.h>
 #include <sofa/core/ExecParams.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <fstream>

--- a/Regression_test/Regression_test.cpp
+++ b/Regression_test/Regression_test.cpp
@@ -3,7 +3,7 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/FileSystem.h>
 
-using sofa::helper::testing::BaseTest;
+using sofa::testing::BaseTest;
 
 #include <SofaComponentAll/initSofaComponentAll.h>
 
@@ -15,7 +15,7 @@ using sofa::helper::testing::BaseTest;
 
 #include <SofaSimulationGraph/DAGSimulation.h>
 
-using sofa::helper::testing::BaseSimulationTest;
+using sofa::testing::BaseSimulationTest;
 #include <SofaValidation/CompareState.h>
 #include <SofaValidation/CompareTopology.h>
 

--- a/Regression_test/Regression_test.h
+++ b/Regression_test/Regression_test.h
@@ -23,7 +23,7 @@
 #define SOFA_REGRESSION_TEST_H
 
 #include "RegressionSceneList.h"
-#include <SofaSimulationGraph/testing/BaseSimulationTest.h>
+#include <sofa/testing/BaseSimulationTest.h>
 
 namespace sofa 
 {
@@ -48,7 +48,7 @@ namespace sofa
 ///
 /// If the result of the simulation changed voluntarily, these files must be manually deleted (locally) so they can be created again (by running the test).
 /// Their modifications must be pushed to the repository.
-class BaseRegression_test : public sofa::helper::testing::BaseSimulationTest, public ::testing::WithParamInterface<RegressionSceneData>
+class BaseRegression_test : public sofa::testing::BaseSimulationTest, public ::testing::WithParamInterface<RegressionSceneData>
 {
 public:
     /// return the name of the file being tested without path nor extension


### PR DESCRIPTION
Some deprecated testing headers are used, so this PR change those to the normal ones.

(those headers will be disabled in a PR in SOFA, before v21.12 release)