### PR TITLE
Fix weird behavior with gcc and string/char

### DIFF
--- a/Regression_test/RegressionSceneList.h
+++ b/Regression_test/RegressionSceneList.h
@@ -72,11 +72,11 @@ public:
 
     RegressionSceneList();
 
-    static inline const std::string s_listSuffix = ".regression-tests";
+    static inline const char* s_listSuffix = ".regression-tests";
 
     const std::string getListType() { return  "RegressionSceneList"; }
     const std::string getListPrefix() { return  ""; }
-    const std::string getListFilename() { return static_cast<T*>(this)->getListPrefix() + s_listSuffix; }
+    const std::string getListFilename() { return static_cast<T*>(this)->getListPrefix() + std::string(s_listSuffix); }
 
 
 protected:


### PR DESCRIPTION
Weird bug(??) where gcc only could not store a string into a static (inline) const std::string but can store this string into a static (inline) const char* ??