### PR TITLE
Fix CMake warning from deprecated function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,4 @@ cmake_minimum_required(VERSION 3.12)
 
 find_package(Sofa.Config) # Load SofaMacros
 
-sofa_add_application(Regression_test Regression_test)
+sofa_add_subdirectory(application Regression_test Regression_test)


### PR DESCRIPTION
The warning was:

CMake Warning at Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake:472 (message):
  Deprecated macro.  Use 'sofa_add_subdirectory(application ...)' instead.
Call Stack (most recent call first):
  plugins/Regression/CMakeLists.txt:7 (sofa_add_application)