### PR TITLE
Allow .py scenes (SofaPython3) for regression testing

### DIFF
--- a/Regression_test/CMakeLists.txt
+++ b/Regression_test/CMakeLists.txt
@@ -3,10 +3,13 @@ project(Regression_test LANGUAGES CXX)
 
 include(cmake/environment.cmake)
 
+find_package(Sofa.Simulation.Graph REQUIRED)
+sofa_find_package(Sofa.Testing REQUIRED)
 # regression_test itself just needs Sofa.Component.Playback
 # But Sofa.Component ensures that we have all the Sofa.Component.* components needed in the tested scenes.
-find_package(Sofa.Component REQUIRED)
-find_package(Sofa.Testing REQUIRED)
+sofa_find_package(Sofa.Component REQUIRED)
+
+sofa_find_package(SofaPython3 QUIET)
 
 set(HEADER_FILES
     RegressionSceneList.h
@@ -14,15 +17,21 @@ set(HEADER_FILES
     Regression_test.h
 )
 
-set(SOURCE_FILES
+set(SOURCE_FILES    
+    main.cpp
     RegressionSceneList.cpp
     Regression_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
 add_definitions("-DSOFA_SRC_DIR=\"${CMAKE_SOURCE_DIR}\"")
-target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing)
-target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Graph Sofa.Component)
+target_link_libraries(${PROJECT_NAME} PUBLIC gtest)
+if(SofaPython3_FOUND)
+    message("regression will be compiled with SofaPython3 support.")
+    target_link_libraries(${PROJECT_NAME} PUBLIC SofaPython3::Plugin)
+endif()
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -26,10 +26,11 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::FileSystem;
-#include <sofa/testing/BaseTest.h>
 #include <sofa/core/ExecParams.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <fstream>
+
+#include <gtest/gtest.h>
 
 namespace sofa
 {

--- a/Regression_test/Regression_test.cpp
+++ b/Regression_test/Regression_test.cpp
@@ -3,8 +3,6 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/FileSystem.h>
 
-using sofa::testing::BaseTest;
-
 #include <sofa/component/playback/ReadState.h>
 #include <sofa/component/playback/WriteState.h>
 #include <sofa/component/playback/ReadTopology.h>
@@ -14,8 +12,6 @@ using sofa::testing::BaseTest;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 #include <sofa/simulation/graph/SimpleApi.h>
-
-using sofa::testing::BaseSimulationTest;
 
 #include <sofa/core/MechanicalParams.h>
 

--- a/Regression_test/Regression_test.h
+++ b/Regression_test/Regression_test.h
@@ -23,7 +23,9 @@
 #define SOFA_REGRESSION_TEST_H
 
 #include "RegressionSceneList.inl"
-#include <sofa/testing/BaseSimulationTest.h>
+
+#include <sofa/simulation/Node.h>
+#include <gtest/gtest.h>
 
 namespace sofa 
 {
@@ -48,7 +50,7 @@ namespace sofa
 ///
 /// If the result of the simulation changed voluntarily, these files must be manually deleted (locally) so they can be created again (by running the test).
 /// Their modifications must be pushed to the repository.
-class BaseRegression_test : public sofa::testing::BaseSimulationTest, public ::testing::WithParamInterface<RegressionSceneData>
+class BaseRegression_test : public ::testing::Test, public ::testing::WithParamInterface<RegressionSceneData>
 {
 public:
     /// return the name of the file being tested without path nor extension

--- a/Regression_test/main.cpp
+++ b/Regression_test/main.cpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/simulation/graph/init.h>
+
+#include <gtest/gtest.h>
+
+#if __has_include(<SofaPython3/initModule.h>)
+#include <SofaPython3/initModule.h>
+#endif
+
+SOFA_EXPORT_DYNAMIC_LIBRARY int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+
+    sofa::simulation::graph::init();
+
+#if __has_include(<SofaPython3/initModule.h>)
+    sofapython3::init();
+#endif
+
+    const int ret =  RUN_ALL_TESTS();
+
+    sofa::simulation::graph::cleanup();
+
+    return ret;
+}


### PR DESCRIPTION
- Force-load SofaPython3 at run-time (if compiled with it)
- remove usage of useless Sofa.Testing API, it just needs gtest actually
- add its own main() (instead of SofaGTestMain)

⚠️ needs
- https://github.com/sofa-framework/SofaPython3/pull/374
