### PR TITLE
ADD way to specify multiples folders for regression test search

### DIFF
--- a/Regression_test/RegressionSceneList.h
+++ b/Regression_test/RegressionSceneList.h
@@ -64,9 +64,6 @@ template <typename T>
 class RegressionSceneList
 {
 public:
-    std::string m_scenesDir;
-    std::string m_referencesDir;
-
     /// List of regression Data to perform @sa RegressionSceneTest_Data
     std::vector<RegressionSceneData> m_scenes;
 


### PR DESCRIPTION
Add mechanism to iterate through multiple folders given in the two environment paths for scene and reference files.
This allow to also launch plugin regression test. 