### PR TITLE
[src] Revert inheritance with sofa::testing::BaseTest to use sofa::testing::MessageAsTestFailure

### DIFF
--- a/Regression_test/CMakeLists.txt
+++ b/Regression_test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCE_FILES
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
 add_definitions("-DSOFA_SRC_DIR=\"${CMAKE_SOURCE_DIR}\"")
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Graph Sofa.Component)
 target_link_libraries(${PROJECT_NAME} PUBLIC gtest)

--- a/Regression_test/Regression_test.h
+++ b/Regression_test/Regression_test.h
@@ -23,9 +23,10 @@
 #define SOFA_REGRESSION_TEST_H
 
 #include "RegressionSceneList.inl"
+#include <sofa/testing/BaseTest.h>
 
 #include <sofa/simulation/Node.h>
-#include <gtest/gtest.h>
+
 
 namespace sofa 
 {
@@ -50,7 +51,7 @@ namespace sofa
 ///
 /// If the result of the simulation changed voluntarily, these files must be manually deleted (locally) so they can be created again (by running the test).
 /// Their modifications must be pushed to the repository.
-class BaseRegression_test : public ::testing::Test, public ::testing::WithParamInterface<RegressionSceneData>
+class BaseRegression_test : public sofa::testing::BaseTest, public ::testing::WithParamInterface<RegressionSceneData>
 {
 public:
     /// return the name of the file being tested without path nor extension


### PR DESCRIPTION
sofa::testing::MessageAsTestFailure m_fatal ;
sofa::testing::MessageAsTestFailure m_error ;

defined in BaseTest are needed to rise gtest failure when sofa::helper::logging of type Error or Fatal are emit

