### PR TITLE
Add a way to correctly handle references that are in Regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,16 @@ SOFA Regression Documentation
 ## 1.a - Non regression-tests files ##
 The **Regression_test** program will search for **\*.regression-tests** files in the target directory (SOFA directory).
 This file contains a list of scene to be tested. 
-Each line of the list file must contain: 
+
+The first information that is not a comment in this file should be the path to the reference folder containing all data needed for regression testing. This path should be relative to this folder path. 
+The folder should be structured as the folder containing this file and each reference of each scene should have a relative path to the reference folder equivalent to the relative path of the corresponding scene in this folder. 
+
+--> e.g. for the scene in `very/specific/path/to/MyScene.scn`, a reference with the same name as the scene should be found in `referenceFolder/very/specific/path/to` 
+
+--> A special string can be use while specifying this path: `$REGRESSION_DIR`. If used at the beginning of the path, then it will be used as an absolute path with `$REGRESSION_DIR` replaced by the content of the environment variable with the same name. 
+Use this, when the reference are not in the repository containing the examples but directly in the repo Regression
+
+Each following line of the list file must contain: 
 1. A local path to the scene
 2. The number of simulation steps to run
 3. A numerical epsilon for comparison 
@@ -25,6 +34,10 @@ Each line of the list file must contain:
 See for example: SOFA_DIR/examples/RegressionStateScenes.regression-tests
 ```
 ### Demo scenes ###
+# References folder
+../path/to/the/references (OR $REGRESSION_DIR/path/to/the/references)
+
+# Tested Scenes 
 Demos/caduceus.scn 100 1e-3 0 1
 Demos/TriangleSurfaceCutting.scn 100 1e-4 1 1
 Demos/liver.scn 100 1e-4 1 1
@@ -62,7 +75,8 @@ For the moment non regression tests class are:
 ## 2.a - Full solution: By setting up environment
 The program **Regression_test** can not take arguments because of its internal mechanism. Thus to run it correctly, several Environment variables need to be set :
 - REGRESSION_SCENES_DIR : path to the root folder containing the scenes (usually SOFA_SRC_DIR/examples)
-- REGRESSION_REFERENCES_DIR : path to the root folder containing the references (this repository/References)
+- REGRESSION_REFERENCES_DIR : path to the root folder containing the references (this repository/References). The reference file normally provides a path to the reference directory, but when it doesn't exist, this will be the fallback.
+- REGRESSION_DIR : path to the root directory of this project sources. This is only required when the references used by your project are in the Regression repo (this is the case for SOFA). If so, the path specified in your reference file should start with `$REGRESSION_DIR`
 - SOFA_ROOT : path to sofa build directory.
 - SOFA_PLUGIN_PATH : path to the plugin library to be loaded by "required plugin" in the scenes (usually SOFA_ROOT/lib)
 

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -122,7 +122,7 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
             msg_error(msgHeader) << "The reference path contains '$REGRESSION_DIR', and the environment variable REGRESSION_DIR is not set.";
             return;
         }
-        msg_info()<<"Use REGRESSION_DIR as prefix"<<std::endl;
+        msg_info(msgHeader)<<"Use REGRESSION_DIR as prefix";
         fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(14);
     }
     else
@@ -133,7 +133,7 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
     // Check if the reference folder does exist
     if (!referencesDir.empty())
     {
-        msg_info()<<"Regression file path set for '"<<listFile<<"' : "<<fullPathReferenceDir<<std::endl;
+        msg_info(msgHeader)<<"Regression file path : "<<fullPathReferenceDir;
         if (!sofa::helper::system::FileSystem::exists(fullPathReferenceDir))
         {
             // relative reference path is wrong, check if the user set a env var instead

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -123,7 +123,7 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
             return;
         }
         msg_info(msgHeader)<<"Use REGRESSION_DIR as prefix";
-        fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(14);
+        fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(15);
     }
     else
     {

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -217,9 +217,11 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
         if (results.size() > 5)
             period = std::stoi(results[5]);
 
+
+
         std::string scene = listDir + "/" + sceneFromList;
         std::string sceneFromScenesDir(scene);
-        sceneFromScenesDir.erase( sceneFromScenesDir.find(scenesDir+"/"), scenesDir.size()+1 );
+        sceneFromScenesDir.erase( sceneFromScenesDir.find(scenesDir+(scenesDir[scenesDir.size()-1] == '/' ? "" : "/")), scenesDir.size()+1 );
         std::string reference = fullPathReferenceDir + "/" + sceneFromList + ".reference";
 
 #ifdef WIN32

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -32,6 +32,8 @@ using sofa::helper::system::FileSystem;
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 namespace sofa
 {
 
@@ -110,7 +112,23 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
             break;
     }
 
-    std::string fullPathReferenceDir = listDir + "/" + referencesDir;
+    std::string fullPathReferenceDir;
+    //Check if reference dir starts with $REFERENCE_DIR
+    if (referencesDir.starts_with("$REFERENCE_DIR"))
+    {
+        char* refDirVar = getenv("REFERENCE_DIR");
+        if (refDirVar == nullptr)
+        {
+            msg_error(msgHeader) << "The reference path contains '$REFERENCE_DIR', and the environment variable REFERENCE_DIR is not set.";
+            return;
+        }
+        fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(14);
+    }
+    else
+    {
+        fullPathReferenceDir = listDir + "/" + referencesDir;
+    }
+
     // Check if the reference folder does exist
     if (!referencesDir.empty())
     {

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -122,6 +122,7 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
             msg_error(msgHeader) << "The reference path contains '$REGRESSION_DIR', and the environment variable REGRESSION_DIR is not set.";
             return;
         }
+        msg_info()<<"Use REGRESSION_DIR as prefix"<<std::endl;
         fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(14);
     }
     else
@@ -132,6 +133,7 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
     // Check if the reference folder does exist
     if (!referencesDir.empty())
     {
+        msg_info()<<"Regression file path set for '"<<listFile<<"' : "<<fullPathReferenceDir<<std::endl;
         if (!sofa::helper::system::FileSystem::exists(fullPathReferenceDir))
         {
             // relative reference path is wrong, check if the user set a env var instead

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -113,13 +113,13 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
     }
 
     std::string fullPathReferenceDir;
-    //Check if reference dir starts with $REFERENCE_DIR
-    if (referencesDir.starts_with("$REFERENCE_DIR"))
+    //Check if reference dir starts with $REGRESSION_DIR
+    if (referencesDir.starts_with("$REGRESSION_DIR"))
     {
-        char* refDirVar = getenv("REFERENCE_DIR");
+        char* refDirVar = getenv("$REGRESSION_DIR");
         if (refDirVar == nullptr)
         {
-            msg_error(msgHeader) << "The reference path contains '$REFERENCE_DIR', and the environment variable REFERENCE_DIR is not set.";
+            msg_error(msgHeader) << "The reference path contains '$REGRESSION_DIR', and the environment variable $REGRESSION_DIR is not set.";
             return;
         }
         fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(14);

--- a/Regression_test/RegressionSceneList.inl
+++ b/Regression_test/RegressionSceneList.inl
@@ -116,10 +116,10 @@ void RegressionSceneList<T>::collectScenesFromList(const std::string& scenesDir,
     //Check if reference dir starts with $REGRESSION_DIR
     if (referencesDir.starts_with("$REGRESSION_DIR"))
     {
-        char* refDirVar = getenv("$REGRESSION_DIR");
+        char* refDirVar = getenv("REGRESSION_DIR");
         if (refDirVar == nullptr)
         {
-            msg_error(msgHeader) << "The reference path contains '$REGRESSION_DIR', and the environment variable $REGRESSION_DIR is not set.";
+            msg_error(msgHeader) << "The reference path contains '$REGRESSION_DIR', and the environment variable REGRESSION_DIR is not set.";
             return;
         }
         fullPathReferenceDir = std::string(refDirVar) + referencesDir.substr(14);


### PR DESCRIPTION
Use $REFERENCE_DIR in reference file to be able to specify an absolute path when reference directory is non deterministically defined relatively to reference file. e.g. for SOFA example scene when plugins are fetched in build dir. 

No If the reference path given in the reference file starts with $REGRESSION_DIR, it will use the content of the environment variable REGRESSION_DIR to complete the given path. 

This is for https://github.com/sofa-framework/sofa/pull/5332 