### PR TITLE
Make the scene test name to include extension

### DIFF
--- a/Regression_test/Regression_test.cpp
+++ b/Regression_test/Regression_test.cpp
@@ -27,7 +27,7 @@ std::string BaseRegression_test::getTestName(const ::testing::TestParamInfo<Regr
         pos++;
 
     std::string name = path.substr(pos);
-    name = name.substr(0, name.find_last_of(".")); // get name of the file without extension
+    std::replace(name.begin(), name.end(), '.', '_');
 
     return name;
 }


### PR DESCRIPTION
The test name only consists in the filename w/o extension.
This can be a problem as gtest does not permit same test name, and if the regressions include the same file name even if they are not in the same directory or same extension (the case in BeamAdapter)

This PR just add the extension in the name so it solves the problem if the filename is the same but not the extension (obvious case: scn and py)

A better solution would be to make the scene name truly unique (maybe keeping a list somewhere and check for unique names).