### PR TITLE
[scripts] Update SofaRegressionProgram to support both JSON and CSV format

### DIFF
--- a/tools/ReferenceFileIO.py
+++ b/tools/ReferenceFileIO.py
@@ -68,7 +68,7 @@ def write_JSON_reference_file(file_path, numpy_data):
         write_file.write(json.dumps(numpy_data, cls=NumpyArrayEncoder).encode('utf-8'))
 
 def read_JSON_reference_file(file_path):
-    with gzip.open(self.filenames[meca_id], 'r') as zipfile:
+    with gzip.open(file_path, 'r') as zipfile:
         decoded_array = json.loads(zipfile.read().decode('utf-8'))
 
         keyframes = []

--- a/tools/RegressionSceneData.py
+++ b/tools/RegressionSceneData.py
@@ -228,14 +228,6 @@ class RegressionSceneData:
 
 
     def compare_references(self, format = "JSON"):
-        if format == "CSV":
-            return self.compare_csv_references()
-        elif format == "JSON":
-            return self.compare_json_references()
-        else:
-            print(f"Unsupported format: {format}")
-            raise ValueError(f"Unsupported format: {format}")
-
         pbar_simu = tqdm(total=float(self.steps), disable=self.disable_progress_bar)
         pbar_simu.set_description("compare_references: " + self.file_scene_path)
 
@@ -247,14 +239,15 @@ class RegressionSceneData:
             ref_values = []         # List[List[np.ndarray]]
         elif format == "JSON":
             numpy_data = [] # List<map>
-            
+        else:
+            print(f"Unsupported format: {format}")
+            raise ValueError(f"Unsupported format: {format}")
 
         # Outputs init
         self.total_error = []
         self.error_by_dof = []
         self.nbr_tested_frame = 0
         self.regression_failed = False
-
 
         # --------------------------------------------------
         # Load reference files


### PR DESCRIPTION
based on PR #88 

**Edit 2026-2-11:**
Add possibility to read or write references either in csv or json format. Keep json as default one for the moment

Exemple of format for a MecanicalObject in Rigid template:
```
# format_version=1.0
# dof_per_point=7
# num_points=631
# layout=time,X0,Y1,Z1,Qx1,Qy1,Qz1,Qw1,...,Xn,Yn,Zn,QxN,QyN,QzN1,QwN
0.0,9.91329,71.9,-5.27454,0.0,-0.7071067811865476,0.0,0.7071067811865476,...
0.8,9.91329,71.9,-5.27454,0.0,-0.7071067811865476,0.0,0.7071067811865476,...
...
```