### PR TITLE
[scripts] Fix ReplayState class to use the IO method and add the id of scene to replay form the input list

### DIFF
--- a/SofaRegressionProgram.py
+++ b/SofaRegressionProgram.py
@@ -92,9 +92,9 @@ class RegressionProgram:
 
         return nbr_scenes
 
-    def replay_references(self, id_set=0):
+    def replay_references(self, id_scene, id_set=0):
         scene_list = self.scene_sets[id_set]
-        scene_list.replay_references(0)
+        scene_list.replay_references(id_scene)
 
 
 
@@ -123,7 +123,7 @@ def make_parser():
     
     parser.add_argument('--replay', 
                         dest='replay', 
-                        help="test option to replay reference",
+                        help=f"Will launch runSofa on the scene number X (input number) in the input the list of the {regression_file_extension} file given as input and display the scene references aside from the simulation",
                         type=int)
     
     parser.add_argument(
@@ -155,6 +155,7 @@ def make_parser():
 Examples:
     python SofaRegressionProgram.py --input ./scenes
     python SofaRegressionProgram.py --input ./scenes --filter \"$demo.*.scn\"
+    python SofaRegressionProgram.py --input ./scenes --replay 5
         '''
 
     return parser
@@ -178,9 +179,9 @@ if __name__ == '__main__':
         print("Legacy regression mode activated.")
         reg_prog.legacy_mode = True
 
-    replay = bool(args.replay)
-    if replay:
-        reg_prog.replay_references()
+    replayId = int(args.replay)
+    if replayId is not None:
+        reg_prog.replay_references(replayId)
         sys.exit()
 
     if args.write_mode:

--- a/SofaRegressionProgram.py
+++ b/SofaRegressionProgram.py
@@ -178,9 +178,9 @@ if __name__ == '__main__':
     if args.legacy_mode:
         print("Legacy regression mode activated.")
         reg_prog.legacy_mode = True
-
-    replayId = int(args.replay)
-    if replayId is not None:
+    
+    if args.replay is not None:
+        replayId = int(args.replay)
         reg_prog.replay_references(replayId)
         sys.exit()
 

--- a/tools/RegressionSceneData.py
+++ b/tools/RegressionSceneData.py
@@ -28,10 +28,7 @@ class ReplayState(Sofa.Core.Controller):
         self.frame_step = 0
         self.t_sim = 0.0
 
-        with gzip.open(state_filename, 'r') as zipfile:
-            self.ref_data = json.loads(zipfile.read().decode('utf-8'))
-            for key in self.ref_data:
-                self.keyframes.append(float(key))
+        self.ref_data, self.keyframes = reference_io.read_JSON_reference_file(state_filename)
         
         if (self.keyframes[0] == 0.0): # frame 0.0
             tmp_position = np.asarray(self.ref_data[str(self.keyframes[0])])

--- a/tools/RegressionSceneList.py
+++ b/tools/RegressionSceneList.py
@@ -152,6 +152,10 @@ class RegressionSceneList:
 
 
     def replay_references(self, id_scene):
+        if (id_scene < 0 or id_scene >= len(self.scenes_data_sets)):
+            helper.writeError(f'Id of the scene given for replay: {id_scene} is out of range [0, {len(self.scenes_data_sets) - 1}] from input regression list file.')
+            return
+
         self.scenes_data_sets[id_scene].load_scene()
         self.scenes_data_sets[id_scene].add_compare_state()
         self.scenes_data_sets[id_scene].replay_references()


### PR DESCRIPTION
- Fix error of gzip not there because all input/output zip/unzip has been moved to ReferenceFileIO
- Add option to set the id of the scene to replay. id corresponding to the scene number in the input scene list