### PR TITLE
[scripts] Fix error check to use error_by_dof

### DIFF
--- a/tools/RegressionSceneData.py
+++ b/tools/RegressionSceneData.py
@@ -371,7 +371,7 @@ class RegressionSceneData:
 
         # Final regression returns value
         for meca_id in range(nbr_meca):
-            if self.total_error[meca_id] > self.epsilon:
+            if self.error_by_dof[meca_id] > self.epsilon:
                 self.regression_failed = True
                 return False
 


### PR DESCRIPTION
the threshold given in the file was supposed to be per dof but the script was checking against the sum of all dofs diff. 