### PR TITLE
[Python] Add checks when parsing RegressionStateScenes.regression-tests file

### DIFF
--- a/SofaRegressionProgram/SofaRegressionProgram.py
+++ b/SofaRegressionProgram/SofaRegressionProgram.py
@@ -48,6 +48,12 @@ class RegressionProgram:
             nbr_errors = nbr_errors + scene_list.get_nbr_errors()
         return nbr_errors
 
+    def nbr_parsing_error_in_sets(self):
+        nbr_errors = 0
+        for scene_list in self.scene_sets:
+            nbr_errors = nbr_errors + scene_list.get_nbr_parsing_errors()
+        return nbr_errors
+
     def log_errors_in_sets(self):
         for scene_list in self.scene_sets:
             scene_list.log_scenes_errors()
@@ -212,13 +218,22 @@ if __name__ == '__main__':
 
     np.set_printoptions(legacy='1.25') # revert printing floating-point type in numpy (concretely remove np.array when displaying a list of np.float)
     
+    nbr_parsing_errors = reg_prog.nbr_parsing_error_in_sets()
+
     print ("### Number of sets Done:  " + str(len(reg_prog.scene_sets)))
     print ("### Number of scenes Done:  " + str(nbr_scenes))
+    if nbr_parsing_errors > 0:
+        # Those scenes have not been processed at all: report them as an error
+        # so that an invalid list file cannot silently reduce the test coverage.
+        print ("### Number of invalid lines skipped:  " + str(nbr_parsing_errors))
     if args.write_mode is False:
         print ("### Number of scenes failed:  " + str(reg_prog.nbr_error_in_sets()))
         reg_prog.log_errors_in_sets()
         if reg_prog.nbr_error_in_sets() > 0:
             sys.exit(1) # exit with error(s)
+
+    if nbr_parsing_errors > 0:
+        sys.exit(1) # exit with error(s)
 
     sys.exit(0) # exit without error
 

--- a/SofaRegressionProgram/tools/RegressionSceneList.py
+++ b/SofaRegressionProgram/tools/RegressionSceneList.py
@@ -18,6 +18,7 @@ class RegressionSceneList:
         self.file_dir = os.path.dirname(file_path)
         self.scenes_data_sets = [] # List<RegressionSceneData>
         self.nbr_errors = 0
+        self.nbr_parsing_errors = 0 # number of lines of the list file that could not be used
         self.ref_dir_path = None
         self.disable_progress_bar = disable_progress_bar
         self.verbose = verbose
@@ -26,16 +27,120 @@ class RegressionSceneList:
 
     def get_nbr_scenes(self):
         return len(self.scenes_data_sets)
-    
+
     def get_nbr_errors(self):
         return self.nbr_errors
-    
+
+    def get_nbr_parsing_errors(self):
+        return self.nbr_parsing_errors
+
     def log_scenes_errors(self):
         for scene in self.scenes_data_sets:
             scene.log_errors()
     
     def set_legacy_mode(self, legacy_mode):
         self.legacy_mode = legacy_mode
+
+
+    def parsing_error(self, line_number, message):
+        """Report a line of the list file that cannot be used, and count it.
+
+        A malformed line only invalidates the scene it describes: it must never
+        interrupt the parsing of the file, nor the whole regression run.
+        """
+        self.nbr_parsing_errors = self.nbr_parsing_errors + 1
+        helper.writeError(f"{self.file_path}:{line_number}: {message}")
+
+
+    def parse_scene_line(self, values, line_number):
+        """Parse one scene line of the list file.
+
+        Args:
+            values (list): the whitespace separated fields of the line.
+            line_number (int): line number in the list file, for error reporting.
+
+        Returns:
+            RegressionSceneData: the described scene, or None if the line is
+            invalid. In that case the error has already been reported.
+        """
+        expected_fields = "<scene path> <steps> <epsilon> <meca_in_mapping> <dump_number_step>"
+        if len(values) > 5:
+            helper.writeWarning(f"{self.file_path}:{line_number}: expecting at most 5 fields "
+                                f"({expected_fields}), got {len(values)}. Extra fields are ignored.")
+
+        steps = 1000
+        epsilon = 0.0001
+        meca_in_mapping = False
+        dump_number_step = 1
+
+        if len(values) < 2:
+            helper.writeWarning(f"{self.file_path}:{line_number}: cannot evaluate steps. "
+                                f"Default value {steps} will be used instead.")
+        else:
+            try:
+                steps = int(values[1])
+            except ValueError:
+                self.parsing_error(line_number, f"steps must be an integer, got '{values[1]}'. "
+                                                f"Expecting: {expected_fields}. Skipping this scene.")
+                return None
+            if steps <= 0:
+                self.parsing_error(line_number, f"steps must be strictly positive, got {steps}. "
+                                                f"Skipping this scene.")
+                return None
+
+        if len(values) < 3:
+            helper.writeWarning(f"{self.file_path}:{line_number}: cannot evaluate epsilon. "
+                                f"Default value {epsilon} will be used instead.")
+        else:
+            try:
+                epsilon = float(values[2])
+            except ValueError:
+                self.parsing_error(line_number, f"epsilon must be a number, got '{values[2]}'. "
+                                                f"Expecting: {expected_fields}. Skipping this scene.")
+                return None
+            if epsilon < 0:
+                self.parsing_error(line_number, f"epsilon must be positive, got {epsilon}. "
+                                                f"Skipping this scene.")
+                return None
+
+        if len(values) < 4:
+            helper.writeWarning(f"{self.file_path}:{line_number}: cannot evaluate meca_in_mapping. "
+                                f"Default value {meca_in_mapping} will be used instead.")
+        elif values[3] not in ('0', '1'):
+            self.parsing_error(line_number, f"meca_in_mapping must be 0 or 1, got '{values[3]}'. "
+                                            f"Expecting: {expected_fields}. Skipping this scene.")
+            return None
+        else:
+            meca_in_mapping = (values[3] == '1')  # converting string to Bool always gives True
+
+        if len(values) < 5:
+            helper.writeWarning(f"{self.file_path}:{line_number}: cannot evaluate dump_number_step. "
+                                f"Default value {dump_number_step} will be used instead.")
+        else:
+            try:
+                dump_number_step = int(values[4])
+            except ValueError:
+                self.parsing_error(line_number, f"dump_number_step must be an integer, got '{values[4]}'. "
+                                                f"Expecting: {expected_fields}. Skipping this scene.")
+                return None
+            # dump_number_step is used as a divider of the number of steps
+            if dump_number_step <= 0:
+                self.parsing_error(line_number, f"dump_number_step must be strictly positive, "
+                                                f"got {dump_number_step}. Skipping this scene.")
+                return None
+
+        full_file_path = os.path.normpath(os.path.join(self.file_dir, values[0]))
+        if not os.path.isfile(full_file_path):
+            self.parsing_error(line_number, f"scene file does not exist: {full_file_path}. "
+                                            f"Skipping this scene.")
+            return None
+
+        full_ref_file_path = os.path.normpath(os.path.join(self.ref_dir_path, values[0]))
+
+        return RegressionSceneData.RegressionSceneData(full_file_path, full_ref_file_path,
+                                                       steps, epsilon, meca_in_mapping, dump_number_step,
+                                                       self.disable_progress_bar, self.verbose)
+
 
     def process_file(self):
         with open(self.file_path, 'r') as the_file:
@@ -44,7 +149,9 @@ class RegressionSceneList:
         
         count = 0
         for idx, line in enumerate(data):
-            if line[0] == "#":
+            line_number = idx + 1
+
+            if line.startswith("#"):
                 continue
 
             values = line.split()
@@ -56,14 +163,17 @@ class RegressionSceneList:
                     if ("REGRESSION_DIR" in os.environ):
                         self.ref_dir_path = values[0].replace("$REGRESSION_DIR", os.environ["REGRESSION_DIR"])
                     else:
-                        helper.writeError(f"The environment variable $REGRESSION_DIR is required in {self.file_path} but not set. Please set this variable to the root directory of your regression tests to proceed.")
+                        self.parsing_error(line_number, f"the environment variable $REGRESSION_DIR is required but not set. "
+                                                        f"Please set this variable to the root directory of your regression tests to proceed. "
+                                                        f"No scene of this file will be processed.")
                         return
                 else: # direct absolute or relative path
                     self.ref_dir_path = os.path.join(self.file_dir, values[0])
                     self.ref_dir_path = os.path.abspath(self.ref_dir_path)
 
                 if not os.path.isdir(self.ref_dir_path):
-                    helper.writeError(f'Reference directory mentioned by file \'{self.file_path}\' does not exist: {self.ref_dir_path}')
+                    self.parsing_error(line_number, f"reference directory does not exist: {self.ref_dir_path}. "
+                                                    f"No scene of this file will be processed.")
                     return
 
                 if self.verbose:
@@ -76,41 +186,11 @@ class RegressionSceneList:
                     helper.writeLog(f'Filtered out {self.filter}: {values[0]}')
                 continue
 
-            steps = 1000
-            epsilon = 0.0001
-            meca_in_mapping = False
-            dump_number_step = 1
-
-            if len(values) < 2:
-                helper.writeWarning(f"Cannot evaluate steps from line: {line}. Default value {steps} will be used instead.")
-            else:
-                steps = int(values[1])
-
-            if len(values) < 3:
-                helper.writeWarning(
-                    f"Cannot evaluate epsilon from line: {line}. Default value {epsilon} will be used instead.")
-            else:
-                epsilon = float(values[2])
-
-            if len(values) < 4:
-                helper.writeWarning(
-                    f"Cannot evaluate meca_in_mapping from line: {line}. Default value {meca_in_mapping} will be used instead.")
-            else:
-                if values[3] == '1':  # converting string to Bool always gives True
-                    meca_in_mapping = True
-
-            if len(values) < 5:
-                helper.writeWarning(
-                    f"Cannot evaluate dump_number_step from line: {line}. Default value {dump_number_step} will be used instead.")
-            else:
-                dump_number_step = int(values[4])
-
-            full_file_path = os.path.normpath(os.path.join(self.file_dir, values[0]))
-            full_ref_file_path = os.path.normpath(os.path.join(self.ref_dir_path, values[0]))
-
-            scene_data = RegressionSceneData.RegressionSceneData(full_file_path, full_ref_file_path,
-                                                                 steps, epsilon, meca_in_mapping, dump_number_step,
-                                                                 self.disable_progress_bar, self.verbose)
+            # An invalid line is reported and skipped: the other scenes of the
+            # file must still be processed.
+            scene_data = self.parse_scene_line(values, line_number)
+            if scene_data is None:
+                continue
 
             #scene_data.printInfo()
             self.scenes_data_sets.append(scene_data)


### PR DESCRIPTION
On the SOFA codebase, the regression was crashing for `FEMBAR_ShewchukPCGLinearSolver.scn ` because the RegressionStateScenes.regression-tests  is missing an argument (nb of steps) for this scene. Apparently the C++ version is not bothered....